### PR TITLE
Fix code scanning alert no. 139: Uncontrolled data used in path expression

### DIFF
--- a/SEM 1/SSD/Project/7_Nutrition_Counter/UI_Project/app.py
+++ b/SEM 1/SSD/Project/7_Nutrition_Counter/UI_Project/app.py
@@ -59,7 +59,10 @@ def upload_file():
 
     if file and allowed_file(file.filename):
         filename = "sampleImage." + file.filename.rsplit(".", 1)[1].lower()
-        file.save(os.path.join(app.config["uploadFolder"], filename))
+        fullpath = os.path.normpath(os.path.join(app.config["uploadFolder"], filename))
+        if not fullpath.startswith(app.config["uploadFolder"]):
+            return render_template('upload.html', error="Invalid file path.")
+        file.save(fullpath)
         run_script("code1.py")
         data = run_script("analyseData.py")
         data = data.stdout.strip()


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/139](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/139)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root upload folder. This will prevent directory traversal attacks.

1. Normalize the path using `os.path.normpath`.
2. Check that the normalized path starts with the root upload folder.
3. If the check fails, raise an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
