### PR TITLE
Fix code scanning alert no. 140: Uncontrolled data used in path expression

### DIFF
--- a/SEM 1/SSD/Project/ssd_pro_old/UI_Project/app.py
+++ b/SEM 1/SSD/Project/ssd_pro_old/UI_Project/app.py
@@ -35,7 +35,10 @@ def upload_file():
 
     if file and allowed_file(file.filename):
         filename = "sampleImage." + file.filename.rsplit(".", 1)[1].lower()
-        file.save(os.path.join(app.config["uploadFolder"], filename))
+        fullpath = os.path.normpath(os.path.join(app.config["uploadFolder"], filename))
+        if not fullpath.startswith(app.config["uploadFolder"]):
+            return render_template('FrontEnd.html', error="Invalid file path.")
+        file.save(fullpath)
         run_script("code1.py")
         data = run_script("analyseData.py")
         # capture_output=True,


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/140](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/140)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the intended upload directory. This will prevent path traversal attacks by ensuring that the file is saved within the designated directory.

1. Normalize the constructed file path using `os.path.normpath`.
2. Check that the normalized path starts with the `uploadFolder`.
3. Raise an exception or return an error if the path is not within the `uploadFolder`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
