### PR TITLE
Fix code scanning alert no. 138: Flask app is run in debug mode

### DIFF
--- a/SEM 1/SSD/Labs/11/flasktutorial/main.py
+++ b/SEM 1/SSD/Labs/11/flasktutorial/main.py
@@ -186,4 +186,6 @@ def display_user_shoes_render():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/138](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/138)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

1. Modify the `app.run()` method to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode.
2. Import the `os` module to access environment variables.
3. Update the `app.run()` call to use the value of the `FLASK_DEBUG` environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
