### PR TITLE
Fix code scanning alert no. 137: Flask app is run in debug mode

### DIFF
--- a/SEM 1/SSD/Labs/11/reference/main.py
+++ b/SEM 1/SSD/Labs/11/reference/main.py
@@ -187,7 +187,9 @@ def display_user_shoes_render():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)
 
 
 '''


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/137](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/137)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

1. Modify the `app.run()` method to check an environment variable to determine whether to enable debug mode.
2. Import the `os` module to access environment variables.
3. Update the `app.run()` call to use the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
