### PR TITLE
Fix code scanning alert no. 135: Flask app is run in debug mode

### DIFF
--- a/SEM 1/SSD/Project/7_Nutrition_Counter/UI_Project/app.py
+++ b/SEM 1/SSD/Project/7_Nutrition_Counter/UI_Project/app.py
@@ -118,4 +118,5 @@ def login():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, port= 2000)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, port=2000)


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/135](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/135)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

1. Modify the `app.run()` call to check an environment variable to determine whether to enable debug mode.
2. Update the code to use `os.getenv` to read the environment variable.
3. Ensure that the default behavior is to run without debug mode if the environment variable is not set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
