### PR TITLE
Fix code scanning alert no. 12: Use of externally-controlled format string

### DIFF
--- a/SEM 1/SSD/Project/7_Nutrition_Counter/backend/server.js
+++ b/SEM 1/SSD/Project/7_Nutrition_Counter/backend/server.js
@@ -18,7 +18,7 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(express.json())
 
 app.use((req, res, next) => {
-    console.log(req.path, req.method)
+    console.log('%s %s', req.path, req.method)
     next()
 })
 


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/12](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/12)

To fix the problem, we should ensure that the user-provided `req.path` is safely included in the log message. This can be achieved by using a format specifier (`%s`) and passing the `req.path` as an argument to `console.log`. This approach ensures that the user input is treated as a string and prevents any unintended interpretation of format specifiers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
