### PR TITLE
Fix code scanning alert no. 10: Use of externally-controlled format string

### DIFF
--- a/SEM 1/SSD/ASG/2/MERN-Stack-Tutorial-lesson-14/backend/server.js
+++ b/SEM 1/SSD/ASG/2/MERN-Stack-Tutorial-lesson-14/backend/server.js
@@ -11,7 +11,7 @@ const app = express()
 app.use(express.json())
 
 app.use((req, res, next) => {
-  console.log(req.path, req.method)
+  console.log('Request path: %s, method: %s', req.path, req.method)
   next()
 })
 


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/10](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/10)

To fix the problem, we should ensure that the user-provided `req.path` is safely included in the log message. This can be achieved by using a format specifier (`%s`) and passing `req.path` as an argument to `console.log`. This approach ensures that `req.path` is treated as a string and prevents any unintended interpretation of its content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
