### PR TITLE
Fix code scanning alert no. 13: Use of externally-controlled format string

### DIFF
--- a/SEM 1/SSD/Project/ssd_pro_old/backend/server.js
+++ b/SEM 1/SSD/Project/ssd_pro_old/backend/server.js
@@ -18,7 +18,7 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(express.json())
 
 app.use((req, res, next) => {
-    console.log(req.path, req.method)
+    console.log('Path: %s, Method: %s', req.path, req.method)
     next()
 })
 


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/13](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/13)

To fix the problem, we should ensure that the user-provided `req.path` is safely included in the log message. This can be achieved by using a format specifier (`%s`) and passing `req.path` as an argument to `console.log`. This approach ensures that the path is treated as a string and prevents any unintended format specifier interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
