### PR TITLE
Fix code scanning alert no. 149: Potential use after free

### DIFF
--- a/SEM 1/DSAPS/Assignments/2/2023201058_A2/2023201058_A2_Q1b.cpp
+++ b/SEM 1/DSAPS/Assignments/2/2023201058_A2/2023201058_A2_Q1b.cpp
@@ -652,8 +652,9 @@ public:
             }
 
             // Delete the old heap and update capacity.
-            delete[] heap;
+            int *oldHeap = heap;
             heap = newHeap;
+            delete[] oldHeap;
             capacity = newCapacity;
             // printDetails();
         }


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/149](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/149)

To fix the potential use-after-free issue, we need to ensure that the `heap` pointer is not accessed after it has been freed and before it is reassigned. One way to achieve this is by using a temporary pointer to hold the new memory block and only updating the `heap` pointer after the reallocation process is complete. This ensures that the `heap` pointer remains valid throughout the method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
