### PR TITLE
Fix code scanning alert no. 147: Potential use after free

### DIFF
--- a/SEM 1/DSAPS/Assignments/2/2023201058_A2/2023201058_A2_Q1a.cpp
+++ b/SEM 1/DSAPS/Assignments/2/2023201058_A2/2023201058_A2_Q1a.cpp
@@ -435,12 +435,13 @@ public:
             delete[] heap;
             heap = newHeap;
             capacity = newCapacity;
-            printDetails();
+            
         }
 
         heap[size] = el;
         minHeapifyUp(size);
         size++;
+        printDetails();
         printDetails();
     }
 


### PR DESCRIPTION
Fixes [https://github.com/HemanthReddy1728/IIITH/security/code-scanning/147](https://github.com/HemanthReddy1728/IIITH/security/code-scanning/147)

To fix the problem, we need to ensure that `heap` is not accessed after it has been freed and before it is reassigned. The best way to fix this is to move the `printDetails` call to after the reassignment of `heap`. This ensures that any access to `heap` in `printDetails` will be to valid memory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
